### PR TITLE
handling ge tax

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.27'
+def runeLiteVersion = '1.8.6'
 
 dependencies {
     compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/flippingutilities/controller/apiAuthHandler.java
+++ b/src/main/java/com/flippingutilities/controller/apiAuthHandler.java
@@ -61,6 +61,7 @@ public class apiAuthHandler {
             }
             if (jwt.shouldRefresh()) {
                 log.info("jwt should refresh");
+                hasValidJWT = true; //so it passes the check in refreshJwt
                 CompletableFuture<String> newJwtFuture = plugin.getApiRequestHandler().refreshJwt(jwtString);
                 newJwtFuture.whenComplete((newJwt, exception) -> {
                     if (exception != null) {

--- a/src/main/java/com/flippingutilities/model/AccountData.java
+++ b/src/main/java/com/flippingutilities/model/AccountData.java
@@ -77,6 +77,7 @@ public class AccountData
 			item.setOfferMadeBy();
 			item.setTotalGELimit(geLimit);
 			item.syncState();
+			item.setOfferIds();
 			//when this change was made the field will not exist and will be null
 			if (item.getValidFlippingPanelItem() == null)
 			{

--- a/src/main/java/com/flippingutilities/model/FlippingItem.java
+++ b/src/main/java/com/flippingutilities/model/FlippingItem.java
@@ -37,6 +37,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * This class is the representation of an item that a user is flipping. It contains information about the
@@ -357,6 +358,14 @@ public class FlippingItem
 
 	public void setOfferMadeBy() {
 		history.getCompressedOfferEvents().forEach(o -> o.setMadeBy(flippedBy));
+	}
+
+	public void setOfferIds() {
+		history.getCompressedOfferEvents().forEach(o -> {
+			if (o.getUuid() == null) {
+				o.setUuid(UUID.randomUUID().toString());
+			}
+		});
 	}
 
 	public void resetGeLimit() {

--- a/src/main/java/com/flippingutilities/model/OfferEvent.java
+++ b/src/main/java/com/flippingutilities/model/OfferEvent.java
@@ -104,7 +104,7 @@ public class OfferEvent
 		if (price >= Constants.MAX_PRICE_FOR_GE_TAX) {
 			return price - Constants.GE_TAX_CAP;
 		}
-		int tax = (int)Math.floor(price /100);
+		int tax = (int)Math.floor(price * Constants.GE_TAX);
 		return price - tax;
 	}
 

--- a/src/main/java/com/flippingutilities/ui/gehistorytab/GeHistoryTabOfferPanel.java
+++ b/src/main/java/com/flippingutilities/ui/gehistorytab/GeHistoryTabOfferPanel.java
@@ -10,6 +10,7 @@ import net.runelite.client.ui.FontManager;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
+import java.text.NumberFormat;
 import java.util.List;
 import java.util.function.BiConsumer;
 
@@ -64,14 +65,14 @@ public class GeHistoryTabOfferPanel extends JPanel
 
 		JPanel quantityPanel = new JPanel(new BorderLayout());
 		JLabel leftQuantityLabel = new JLabel("Quantity:");
-		JLabel rightQuantityLabel = new JLabel(String.valueOf(offer.getCurrentQuantityInTrade()));
+		JLabel rightQuantityLabel = new JLabel(NumberFormat.getIntegerInstance().format(offer.getCurrentQuantityInTrade()));
 		quantityPanel.add(leftQuantityLabel, BorderLayout.WEST);
 		quantityPanel.add(rightQuantityLabel, BorderLayout.EAST);
 		quantityPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 
 		JPanel pricePanel = new JPanel(new BorderLayout());
 		JLabel leftPriceLabel = new JLabel("Price Ea:");
-		JLabel rightPriceLabel = new JLabel(String.valueOf(offer.getPrice()));
+		JLabel rightPriceLabel = new JLabel(NumberFormat.getIntegerInstance().format(offer.getPrice()));
 		pricePanel.add(leftPriceLabel, BorderLayout.WEST);
 		pricePanel.add(rightPriceLabel, BorderLayout.EAST);
 		pricePanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);

--- a/src/main/java/com/flippingutilities/utilities/Constants.java
+++ b/src/main/java/com/flippingutilities/utilities/Constants.java
@@ -1,0 +1,9 @@
+package com.flippingutilities.utilities;
+
+public class Constants {
+    //epoch seconds that GE tax was introduced. This is not the exact time, just a close
+    //enough approximation
+    public static int GE_TAX_START = 1639072800;
+    public static int GE_TAX_CAP = 5000000;
+    public static int MAX_PRICE_FOR_GE_TAX = 500000000;
+}

--- a/src/main/java/com/flippingutilities/utilities/Constants.java
+++ b/src/main/java/com/flippingutilities/utilities/Constants.java
@@ -6,4 +6,5 @@ public class Constants {
     public static int GE_TAX_START = 1639072800;
     public static int GE_TAX_CAP = 5000000;
     public static int MAX_PRICE_FOR_GE_TAX = 500000000;
+    public static double GE_TAX = 0.01; // 1%
 }

--- a/src/main/java/com/flippingutilities/utilities/GeHistoryTabExtractor.java
+++ b/src/main/java/com/flippingutilities/utilities/GeHistoryTabExtractor.java
@@ -9,6 +9,7 @@ import net.runelite.api.widgets.Widget;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -19,7 +20,9 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 public class GeHistoryTabExtractor {
-    private static Pattern PRICE_PATTERN = Pattern.compile(">= (.*) each");
+    private static Pattern MULTI_ITEM_PATTERN = Pattern.compile(">= (.*) each");
+    private static Pattern SINGLE_ITEM_PATTERN = Pattern.compile(">(.*) coins");
+    private static Pattern ORIGINAL_PRICE_PATTERN = Pattern.compile("\\((.*) -");
 
     public static List<OfferEvent> convertWidgetsToOfferEvents(Widget[] widgets) {
         //a group of 6 widgets makes up an offer in the trade history tab
@@ -33,7 +36,7 @@ public class GeHistoryTabExtractor {
         GrandExchangeOfferState offerState = getState(widgets.get(2));
         int quantity = widgets.get(4).getItemQuantity();
         int itemId = widgets.get(4).getItemId();
-        int price = getPrice(widgets.get(5));
+        int price = getPrice(widgets.get(5), quantity);
         boolean isBuy = offerState == GrandExchangeOfferState.BOUGHT;
         Instant time = Instant.now();
         int totalQuantity = quantity;
@@ -41,25 +44,39 @@ public class GeHistoryTabExtractor {
         //just making ticksSinceFirst offer something > 2 so it doesn't count as a margin check
         int ticksSinceFirstOffer = 10;
 
-        OfferEvent offerEvent = new OfferEvent(isBuy, itemId, quantity, price, time, slot, offerState, tickArrivedAt, ticksSinceFirstOffer, totalQuantity, true, null, null, false, null,0,0);
+        OfferEvent offerEvent = new OfferEvent(UUID.randomUUID().toString(), isBuy, itemId, quantity, price, time, slot, offerState, tickArrivedAt, ticksSinceFirstOffer, totalQuantity, true, null, null, false, null,0,0);
         return offerEvent;
     }
 
-    private static int getPrice(Widget w) {
+    private static int getPrice(Widget w, int quantity) {
         String text = w.getText();
         String numString = text;
-        if (text.contains("each")) {
-            Matcher m = PRICE_PATTERN.matcher(text);
-            m.find();
-            numString = m.group(1);
+        Matcher m;
+        boolean isTotalPrice = false;
+        if (text.contains(")</col>")) {
+            m = ORIGINAL_PRICE_PATTERN.matcher(text);
+            isTotalPrice = true;
         }
+        else if (text.contains("each")) {
+            m = MULTI_ITEM_PATTERN.matcher(text);
+        }
+        else {
+            m = SINGLE_ITEM_PATTERN.matcher(text);
+        }
+        m.find();
+        numString = m.group(1);
         StringBuilder s = new StringBuilder();
         for (char c : numString.toCharArray()) {
             if (Character.isDigit(c)) {
                 s.append(c);
             }
         }
-        return Integer.parseInt(s.toString());
+
+        int price = Integer.parseInt(s.toString());
+        if (isTotalPrice) {
+            return price/quantity;
+        }
+        return price;
     }
 
     private static GrandExchangeOfferState getState(Widget w) {

--- a/src/main/java/com/flippingutilities/utilities/GeHistoryTabExtractor.java
+++ b/src/main/java/com/flippingutilities/utilities/GeHistoryTabExtractor.java
@@ -48,18 +48,35 @@ public class GeHistoryTabExtractor {
         return offerEvent;
     }
 
+    /**
+     * Gets original price of each item (price before ge tax) from the ge history. We want
+     * to get the price before ge tax bc the the price after ge tax is always calculated by the
+     * OfferEvent class wherever we need to display it. That means that if we get the price after tax
+     * here and then construct an OfferEvent with that price, and then try to display the OfferEvent's price
+     * using OfferEvent.getPrice(), we will effectively be applying the ge tax twice.
+     * @return the original price of each item in the offer
+     */
     private static int getPrice(Widget w, int quantity) {
         String text = w.getText();
         String numString = text;
         Matcher m;
         boolean isTotalPrice = false;
+        // This will trigger anytime there is the ge tax text on an offer in the history
+        // For example when you have that text with the format "({original price} - {ge_tax})
+        // Whenever that text is present, we want to get the original price (NOT THE PRICE
+        // AFTER THE TAX). However, since the original price displayed is not the price of each item
+        //we have to divide it by the quantity to get the original price of each item.
         if (text.contains(")</col>")) {
             m = ORIGINAL_PRICE_PATTERN.matcher(text);
             isTotalPrice = true;
         }
+        //if the case above doesn't trigger that means there is no tax on the item, so we check if "each"
+        //is present which allows us to use the regex for getting the price of each item when multiple
+        //have been traded.
         else if (text.contains("each")) {
             m = MULTI_ITEM_PATTERN.matcher(text);
         }
+        //if this case triggers than it is an offer for a single item that is untaxed
         else {
             m = SINGLE_ITEM_PATTERN.matcher(text);
         }

--- a/src/test/java/com/flippingutilities/GeTaxTest.java
+++ b/src/test/java/com/flippingutilities/GeTaxTest.java
@@ -1,0 +1,62 @@
+package com.flippingutilities;
+
+import com.flippingutilities.model.OfferEvent;
+import com.flippingutilities.utilities.Constants;
+import org.junit.Test;
+
+import java.time.Instant;
+import static org.junit.Assert.assertEquals;
+
+
+public class GeTaxTest {
+
+    @Test
+    public void testGeTaxLow() {
+        OfferEvent offerEvent = new OfferEvent();
+        offerEvent.setBuy(false);
+        offerEvent.setTime(Instant.ofEpochSecond(Constants.GE_TAX_START + 100));
+        offerEvent.setPrice(50);
+
+        assertEquals(offerEvent.getPrice(), 50);
+    }
+
+    @Test
+    public void testGeTaxHigh() {
+        OfferEvent offerEvent = new OfferEvent();
+        offerEvent.setBuy(false);
+        offerEvent.setTime(Instant.ofEpochSecond(Constants.GE_TAX_START + 100));
+        offerEvent.setPrice(2147000000);
+
+        assertEquals(offerEvent.getPrice(), 2147000000 - Constants.GE_TAX_CAP);
+    }
+
+    @Test
+    public void testGeTaxSimple() {
+        OfferEvent offerEvent = new OfferEvent();
+        offerEvent.setBuy(false);
+        offerEvent.setTime(Instant.ofEpochSecond(Constants.GE_TAX_START + 100));
+        offerEvent.setPrice(975);
+
+        assertEquals(offerEvent.getPrice(), 975 - 9);
+    }
+
+    @Test
+    public void testBeforeTax() {
+        OfferEvent offerEvent = new OfferEvent();
+        offerEvent.setBuy(false);
+        offerEvent.setTime(Instant.ofEpochSecond(Constants.GE_TAX_START - 1));
+        offerEvent.setPrice(975);
+
+        assertEquals(offerEvent.getPrice(), 975);
+    }
+
+    @Test
+    public void testNonSellAfterTax() {
+        OfferEvent offerEvent = new OfferEvent();
+        offerEvent.setBuy(true);
+        offerEvent.setTime(Instant.ofEpochSecond(Constants.GE_TAX_START + 100));
+        offerEvent.setPrice(975);
+
+        assertEquals(offerEvent.getPrice(), 975);
+    }
+}

--- a/src/test/java/com/flippingutilities/Utils.java
+++ b/src/test/java/com/flippingutilities/Utils.java
@@ -4,21 +4,22 @@ import com.flippingutilities.model.OfferEvent;
 import net.runelite.api.GrandExchangeOfferState;
 
 import java.time.Instant;
+import java.util.UUID;
 
 public class Utils
 {
 	//constructs an OfferEvent when you don't care about tick specific info.
 	public static OfferEvent offer(boolean isBuy, int currentQuantityInTrade, int price, Instant time, int slot, GrandExchangeOfferState state, int totalQuantityInTrade)
 	{
-		return new OfferEvent(isBuy, 1, currentQuantityInTrade, price, time, slot, state, 0, 10, totalQuantityInTrade, true, null, "gooby", false, null,0,0);
+		return new OfferEvent(UUID.randomUUID().toString(), isBuy, 1, currentQuantityInTrade, price, time, slot, state, 0, 10, totalQuantityInTrade, true, null, "gooby", false, null,0,0);
 	}
 
 	public static OfferEvent offer(boolean isBuy, int currentQuantityInTrade, int price, Instant time, int slot, GrandExchangeOfferState state, int totalQuantityInTrade, int tickSinceFirstOffer)
 	{
-		return new OfferEvent(isBuy, 1, currentQuantityInTrade, price, time, slot, state, 0, tickSinceFirstOffer, totalQuantityInTrade, true, null, "gooby", false, null,0,0);
+		return new OfferEvent(UUID.randomUUID().toString(), isBuy, 1, currentQuantityInTrade, price, time, slot, state, 0, tickSinceFirstOffer, totalQuantityInTrade, true, null, "gooby", false, null,0,0);
 	}
 
 	public static OfferEvent offer(boolean isBuy, int currentQuantityInTrade, int price, Instant time, int slot, GrandExchangeOfferState state, int tickArrivedAt, int tickSinceFirstOffer, int totalQuantityInTrade) {
-		return new OfferEvent(isBuy, 1, currentQuantityInTrade, price, time, slot, state, tickArrivedAt, tickSinceFirstOffer, totalQuantityInTrade, true, null, "gooby", false, null,0,0);
+		return new OfferEvent(UUID.randomUUID().toString(), isBuy, 1, currentQuantityInTrade, price, time, slot, state, tickArrivedAt, tickSinceFirstOffer, totalQuantityInTrade, true, null, "gooby", false, null,0,0);
 	}
 }


### PR DESCRIPTION
- Ge history adder has been fixed
- All sell offers after the ge tax was implemented have their price calculated based on the ge tax. This affects all the displays where a sell offer's price is shown (including the profit)