### PR TITLE
Dispose the login dialog on plugin shutdown

### DIFF
--- a/src/main/java/com/flippingutilities/controller/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/controller/FlippingPlugin.java
@@ -261,6 +261,8 @@ public class FlippingPlugin extends Plugin {
             slotTimersTask = null;
         }
 
+        masterPanel.dispose();
+
         clientToolbar.removeNavigation(navButton);
     }
 

--- a/src/main/java/com/flippingutilities/ui/MasterPanel.java
+++ b/src/main/java/com/flippingutilities/ui/MasterPanel.java
@@ -59,6 +59,7 @@ public class MasterPanel extends PluginPanel
 	private JComboBox<String> accountSelector;
 	private FlippingPlugin plugin;
 	private FastTabGroup tabGroup;
+	private JDialog loginModal;
 
 	/**
 	 * THe master panel is always present. The components added to it are components that should always be visible
@@ -83,7 +84,7 @@ public class MasterPanel extends PluginPanel
 
 		JPanel mainDisplay = new JPanel();
 
-		JDialog loginModal = UIUtilities.createModalFromPanel(this, loginPanel);
+		loginModal = UIUtilities.createModalFromPanel(this, loginPanel);
 		loginPanel.addOnViewChange(() -> {
 			if (loginModal.isVisible()) {
 				loginModal.pack();
@@ -286,5 +287,12 @@ public class MasterPanel extends PluginPanel
 		} else {
 			accountSelector.setVisible(false);
 		}
+	}
+
+	/**
+	* Use to dispose the underlying login dialog on shutdown.
+	*/
+	public void dispose() {
+		loginModal.dispose();
 	}
 }


### PR DESCRIPTION
Fixes an issue where you can keep login dialogs open when shutting down the plugin.

[FlippingItemPanel](https://github.com/Flipping-Utilities/rl-plugin/blob/af842de87b62453c0db223a8957f42122a6fa83c/src/main/java/com/flippingutilities/ui/flipping/FlippingItemPanel.java#L583) also suffer from a similar issue with a CustomizationPanel dialog, although I'm not sure how to fix that one.