### PR TITLE
recipe mismatch bug.....

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.10'
+def runeLiteVersion = '1.8.11'
 
 dependencies {
     compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/flippingutilities/controller/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/controller/FlippingPlugin.java
@@ -941,9 +941,9 @@ public class FlippingPlugin extends Plugin {
     public Map<String, PartialOffer> getOfferIdToPartialOffer(int itemId) {
         return recipeHandler.getOfferIdToPartialOffer(viewRecipeFlipGroupsForCurrentView(), itemId);
     }
-    public void addRecipeFlip(RecipeFlip recipeFlip) {
+    public void addRecipeFlip(RecipeFlip recipeFlip, Recipe recipe) {
         AccountData account = dataHandler.getAccountData(accountCurrentlyViewed);
-        recipeHandler.addRecipeFlip(account.getRecipeFlipGroups(), recipeFlip);
+        recipeHandler.addRecipeFlip(account.getRecipeFlipGroups(), recipeFlip, recipe);
         updateSinceLastRecipeFlipGroupAccountWideBuild = true;
     }
 

--- a/src/main/java/com/flippingutilities/controller/RecipeHandler.java
+++ b/src/main/java/com/flippingutilities/controller/RecipeHandler.java
@@ -229,14 +229,7 @@ public class RecipeHandler {
         }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    public void addRecipeFlip(List<RecipeFlipGroup> recipeFlipGroups, RecipeFlip recipeFlip) {
-        int someInputItemId = recipeFlip.getInputs().keySet().iterator().next();
-        Optional<Recipe> recipeMaybe = getApplicableRecipe(someInputItemId, true);
-        if (!recipeMaybe.isPresent()) {
-            log.warn("not adding recipe, for some reason the recipe flip does not have an associated recipe");
-            return;
-        }
-        Recipe recipe = recipeMaybe.get();
+    public void addRecipeFlip(List<RecipeFlipGroup> recipeFlipGroups, RecipeFlip recipeFlip, Recipe recipe) {
         for (RecipeFlipGroup recipeFlipGroup : recipeFlipGroups) {
             if (recipe.equals(recipeFlipGroup.getRecipe())) {
                 recipeFlipGroup.addRecipeFlip(recipeFlip);

--- a/src/main/java/com/flippingutilities/ui/recipeflips/RecipeFlipCreationPanel.java
+++ b/src/main/java/com/flippingutilities/ui/recipeflips/RecipeFlipCreationPanel.java
@@ -442,7 +442,6 @@ public class RecipeFlipCreationPanel extends JPanel {
         finishButton.setFocusPainted(false);
         finishButton.addActionListener(e -> {
             RecipeFlip recipeFlip = new RecipeFlip(recipe, selectedOffers);
-            log.info("recipe when creating recipe is: {}", recipe);
             plugin.addRecipeFlip(recipeFlip, recipe);
             plugin.getStatPanel().rebuildRecipesDisplay(plugin.viewRecipeFlipGroupsForCurrentView());
             plugin.getStatPanel().rebuildItemsDisplay(plugin.viewItemsForCurrentView());

--- a/src/main/java/com/flippingutilities/ui/recipeflips/RecipeFlipCreationPanel.java
+++ b/src/main/java/com/flippingutilities/ui/recipeflips/RecipeFlipCreationPanel.java
@@ -442,7 +442,8 @@ public class RecipeFlipCreationPanel extends JPanel {
         finishButton.setFocusPainted(false);
         finishButton.addActionListener(e -> {
             RecipeFlip recipeFlip = new RecipeFlip(recipe, selectedOffers);
-            plugin.addRecipeFlip(recipeFlip);
+            log.info("recipe when creating recipe is: {}", recipe);
+            plugin.addRecipeFlip(recipeFlip, recipe);
             plugin.getStatPanel().rebuildRecipesDisplay(plugin.viewRecipeFlipGroupsForCurrentView());
             plugin.getStatPanel().rebuildItemsDisplay(plugin.viewItemsForCurrentView());
 

--- a/src/main/java/com/flippingutilities/ui/statistics/recipes/RecipeFlipPanel.java
+++ b/src/main/java/com/flippingutilities/ui/statistics/recipes/RecipeFlipPanel.java
@@ -9,6 +9,7 @@ import com.flippingutilities.ui.uiutilities.Icons;
 import com.flippingutilities.ui.uiutilities.TimeFormatters;
 import com.flippingutilities.ui.uiutilities.UIUtilities;
 import com.flippingutilities.utilities.Recipe;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.FontManager;
@@ -30,6 +31,7 @@ import java.util.stream.Collectors;
  * are shown in the "combos" tab of the trade history section of an item in the
  * statistics tab.
  */
+@Slf4j
 public class RecipeFlipPanel extends JPanel {
     private JLabel timeDisplay;
     private RecipeFlip recipeFlip;
@@ -228,6 +230,15 @@ public class RecipeFlipPanel extends JPanel {
 
     private JPanel createProfitPanel() {
         long quantity = recipeFlip.getRecipeCountMade(recipe);
+        if (quantity == 0) {
+            JPanel panel = new JPanel(new BorderLayout());
+            panel.setBackground(CustomColors.DARK_GRAY);
+            JLabel label = new JLabel("Mismatched recipe flip (delete it)", SwingConstants.CENTER);
+            label.setFont(FontManager.getRunescapeSmallFont());
+            label.setForeground(CustomColors.TOMATO);
+            panel.add(label, BorderLayout.CENTER);
+            return panel;
+        }
         long profit = recipeFlip.getProfit();
         long profitEach = profit/quantity;
         String profitString = UIUtilities.quantityToRSDecimalStack(profit, true) + " gp";


### PR DESCRIPTION
The Recipe that was resolved when adding a RecipeFlip was different than the recipe of the actual recipe flip (the one bought up by the RecipeFlipCreationPanel). This meant that the RecipeFlipGroup had a recipe that might not have matched its flips. Because a RecipeFlipPanel is rendered using info from the Recipe in its RecipeFlipGroup, this mismatch could cause issues.