### PR TITLE
Show updated wiki buy/sell prices on slots tab items

### DIFF
--- a/src/main/java/com/flippingutilities/controller/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/controller/FlippingPlugin.java
@@ -229,7 +229,7 @@ public class FlippingPlugin extends Plugin {
         flippingPanel = new FlippingPanel(this);
         statPanel = new StatsPanel(this);
         geHistoryTabPanel = new GeHistoryTabPanel(this);
-        slotsPanel = new SlotsPanel(itemManager);
+        slotsPanel = new SlotsPanel(this, itemManager);
         loginPanel = new LoginPanel(this);
 
         masterPanel = new MasterPanel(this, flippingPanel, statPanel, slotsPanel, loginPanel);

--- a/src/main/java/com/flippingutilities/ui/slots/SlotPanel.java
+++ b/src/main/java/com/flippingutilities/ui/slots/SlotPanel.java
@@ -14,8 +14,11 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.time.Instant;
+import java.util.Arrays;
 
 public class SlotPanel extends JPanel {
+    private FlippingPlugin plugin;
     public int itemId;
     private OfferEvent offerEvent;
     private ThinProgressBar progressBar = new ThinProgressBar();
@@ -27,8 +30,22 @@ public class SlotPanel extends JPanel {
     private JLabel timer = new JLabel();
     private Component verticalGap;
 
+    WikiRequest wikiRequest;
+    Instant timeOfRequestCompletion;
+    JLabel wikiBuyText = new JLabel("Wiki insta buy: ");
+    JLabel wikiSellText = new JLabel("Wiki insta sell: ");
+    JLabel wikiBuyTimeText = new JLabel("Wiki insta buy age: ");
+    JLabel wikiSellTimeText = new JLabel("Wiki insta sell age: ");
+    JLabel wikiBuyVal = new JLabel();
+    JLabel wikiSellVal = new JLabel();
+    JLabel wikiBuyTimeVal = new JLabel();
+    JLabel wikiSellTimeVal = new JLabel();
+    JLabel wikiRequestCountDownTimer = new JLabel();
+    JLabel refreshIconLabel = new JLabel();
+    JPopupMenu popup;
 
-    public SlotPanel(Component verticalGap) {
+    public SlotPanel(FlippingPlugin plugin, Component verticalGap) {
+        this.plugin = plugin;
         this.verticalGap = verticalGap;
         setVisible(false);
         setLayout(new BorderLayout());
@@ -73,6 +90,26 @@ public class SlotPanel extends JPanel {
         bottomPanel.setBorder(new EmptyBorder(10, 20,5,20));
         bottomPanel.setLayout(new BoxLayout(bottomPanel, BoxLayout.Y_AXIS));
         bottomPanel.setBackground(CustomColors.DARK_GRAY);
+
+        JPanel wikiBuyPricesPanel = new JPanel(new BorderLayout());
+        wikiBuyPricesPanel.setBackground(CustomColors.DARK_GRAY);
+        wikiBuyText.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);
+        wikiBuyText.setFont(plugin.getFont());
+        wikiBuyPricesPanel.add(wikiBuyText, BorderLayout.WEST);
+        wikiBuyPricesPanel.add(wikiBuyVal, BorderLayout.EAST);
+        wikiBuyPricesPanel.setBorder(new EmptyBorder(6,0,3,0));
+
+        JPanel wikiSellPricesPanel = new JPanel(new BorderLayout());
+        wikiSellPricesPanel.setBackground(CustomColors.DARK_GRAY);
+        wikiSellText.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);
+        wikiSellText.setFont(plugin.getFont());
+        wikiSellPricesPanel.add(wikiSellText, BorderLayout.WEST);
+        wikiSellPricesPanel.add(wikiSellVal, BorderLayout.EAST);
+        wikiSellPricesPanel.setBorder(new EmptyBorder(2,0,8,0));
+        styleValueLabels();
+
+        bottomPanel.add(wikiBuyPricesPanel);
+        bottomPanel.add(wikiSellPricesPanel);
         bottomPanel.add(progressBar);
         bottomPanel.add(Box.createVerticalStrut(10));
         bottomPanel.add(price);
@@ -85,6 +122,9 @@ public class SlotPanel extends JPanel {
             return;
         }
         timer.setText(timeString);
+
+        // update wiki prices
+        updateWikiLabels(plugin.getLastWikiRequest(), plugin.getTimeOfLastWikiRequest());
     }
 
     public boolean shouldUpdate(OfferEvent newOfferEvent) {
@@ -131,8 +171,112 @@ public class SlotPanel extends JPanel {
             else {
                 progressBar.setForeground(ColorScheme.PROGRESS_INPROGRESS_COLOR);
             }
+
         }
     }
 
+    public void updateWikiLabels(WikiRequest wr, Instant requestCompletionTime) {
+        timeOfRequestCompletion = requestCompletionTime;
+        wikiRequest = wr;
 
+        if (wikiRequest == null) {
+            wikiBuyVal.setText("N/A");
+            wikiSellVal.setText("N/A");
+            return;
+        }
+
+        WikiItemMargins wikiItemInfo = wikiRequest.getData().get(this.itemId);
+        if (wikiItemInfo == null) {
+            return;
+        }
+        wikiBuyVal.setText(wikiItemInfo.getHigh()==0? "No data":QuantityFormatter.formatNumber(wikiItemInfo.getHigh()) + " gp");
+        wikiSellVal.setText(wikiItemInfo.getLow()==0? "No data":QuantityFormatter.formatNumber(wikiItemInfo.getLow()) + " gp");
+
+        updateWikiTimeLabels();
+    }
+
+    public void updateWikiTimeLabels() {
+        //can be called before wikiRequest is set cause is is called in the repeating task which can start before the
+        //request is completed
+        if (wikiRequest == null) {
+            wikiBuyTimeVal.setText("Request not made yet");
+            wikiSellTimeVal.setText("Request not made yet");
+            wikiRequestCountDownTimer.setText("N/A");
+            return;
+        }
+        //probably don't need this. Should always be non null if wikiRequest is not null
+        if (timeOfRequestCompletion != null) {
+            long secondsSinceLastRequestCompleted = Instant.now().getEpochSecond() - timeOfRequestCompletion.getEpochSecond();
+            if (secondsSinceLastRequestCompleted >= WikiDataFetcherJob.requestInterval) {
+                wikiRequestCountDownTimer.setText("0");
+                refreshIconLabel.setEnabled(true);
+            }
+            else {
+                refreshIconLabel.setEnabled(false);
+                wikiRequestCountDownTimer.setText(String.valueOf(WikiDataFetcherJob.requestInterval - secondsSinceLastRequestCompleted));
+            }
+        }
+
+        WikiItemMargins wikiItemInfo = wikiRequest.getData().get(this.itemId);
+        if (wikiItemInfo == null) {
+            return;
+        }
+        if (wikiItemInfo.getHighTime() == 0) {
+            wikiBuyTimeVal.setText("No data");
+        }
+        else {
+            wikiBuyTimeVal.setText(TimeFormatters.formatDuration(Instant.ofEpochSecond(wikiItemInfo.getHighTime())));
+        }
+        if (wikiItemInfo.getLowTime() == 0) {
+            wikiBuyTimeVal.setText("No data");
+        }
+        else {
+            wikiSellTimeVal.setText(TimeFormatters.formatDuration(Instant.ofEpochSecond(wikiItemInfo.getLowTime())));
+        }
+    }
+
+    //panel that is shown when someone hovers over the wiki buy/sell value labels
+    private JPanel createWikiHoverTimePanel() {
+        wikiBuyTimeText.setFont(FontManager.getRunescapeSmallFont());
+        wikiBuyTimeText.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);
+        wikiSellTimeText.setFont(FontManager.getRunescapeSmallFont());
+        wikiSellTimeText.setForeground(ColorScheme.GRAND_EXCHANGE_PRICE);
+
+        wikiSellTimeVal.setFont(FontManager.getRunescapeSmallFont());
+        wikiBuyTimeVal.setFont(FontManager.getRunescapeSmallFont());
+
+        JPanel wikiTimePanel = new JPanel();
+        wikiTimePanel.setLayout(new BoxLayout(wikiTimePanel, BoxLayout.Y_AXIS));
+        wikiTimePanel.setBorder(new EmptyBorder(5,5,5,5));
+
+        JPanel buyTimePanel = new JPanel(new BorderLayout());
+        buyTimePanel.add(wikiBuyTimeText, BorderLayout.WEST);
+        buyTimePanel.add(wikiBuyTimeVal, BorderLayout.EAST);
+
+        JPanel sellTimePanel = new JPanel(new BorderLayout());
+        sellTimePanel.add(wikiSellTimeText, BorderLayout.WEST);
+        sellTimePanel.add(wikiSellTimeVal, BorderLayout.EAST);
+
+        wikiTimePanel.add(buyTimePanel);
+        wikiTimePanel.add(Box.createVerticalStrut(5));
+        wikiTimePanel.add(sellTimePanel);
+
+        return wikiTimePanel;
+    }
+
+    private void styleValueLabels() {
+
+        wikiBuyVal.setFont(CustomFonts.SMALLER_RS_BOLD_FONT);
+        wikiBuyVal.setForeground(Color.WHITE);
+        wikiSellVal.setFont(CustomFonts.SMALLER_RS_BOLD_FONT);
+        wikiSellVal.setForeground(Color.WHITE);
+
+        wikiRequestCountDownTimer.setAlignmentY(JLabel.TOP);
+        wikiRequestCountDownTimer.setFont(new Font(Font.SERIF, Font.PLAIN, 9));
+
+        popup = new JPopupMenu();
+        popup.add(createWikiHoverTimePanel());
+        UIUtilities.addPopupOnHover(wikiBuyVal, popup, true);
+        UIUtilities.addPopupOnHover(wikiSellVal, popup, true);
+    }
 }

--- a/src/main/java/com/flippingutilities/ui/slots/SlotsPanel.java
+++ b/src/main/java/com/flippingutilities/ui/slots/SlotsPanel.java
@@ -13,11 +13,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SlotsPanel extends JPanel {
+    private FlippingPlugin plugin;
     private List<SlotPanel> slotPanels;
     private ItemManager itemManager;
     JLabel statusText = new JLabel();
 
-    public SlotsPanel(ItemManager im) {
+    public SlotsPanel(FlippingPlugin plugin, ItemManager im) {
+        this.plugin = plugin;
         itemManager = im;
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         slotPanels = new ArrayList<>();
@@ -26,7 +28,7 @@ public class SlotsPanel extends JPanel {
 
         for (int i = 0; i < 8; i++) {
             Component verticalGap = Box.createVerticalStrut(10);
-            SlotPanel slotPanel = new SlotPanel(verticalGap);
+            SlotPanel slotPanel = new SlotPanel(plugin, verticalGap);
             slotPanels.add(slotPanel);
             slotPanelsContainer.add(slotPanel);
             slotPanelsContainer.add(verticalGap);


### PR DESCRIPTION
Currently the slots interface leaves much to be desired.
If you have it open on the side, you constantly have to switch to the flipping tab to make sure your prices are relevant.
In this commit I copied the wiki buy/sell price lines from the flipping tab to the slots tab.

This will probably require additional changes like user customization of whats shown, and perhaps some refactor to consolidate doubled code between the slots and flipping tab files.