### PR TITLE
Use appropriate tax rates for past offers

### DIFF
--- a/src/main/java/com/flippingutilities/model/OfferEvent.java
+++ b/src/main/java/com/flippingutilities/model/OfferEvent.java
@@ -101,11 +101,13 @@ public class OfferEvent
 	 * @return post tax values
 	 */
 	public int getPrice() {
-		if (buy || time.getEpochSecond() < Constants.GE_TAX_START || Constants.TAX_EXEMPT_ITEMS.contains(itemId)) {
+		final long t = time.getEpochSecond();
+		if (buy || t < Constants.GE_TAX_START || Constants.TAX_EXEMPT_ITEMS.contains(itemId) ||
+			(t >= Constants.GE_TAX_INCREASED && Constants.NEW_TAX_EXEMPT_ITEMS.contains(itemId))) {
 			return price;
 		}
 		// if this occurred prior to the tax rate increasing, use the old rate
-		if (time.getEpochSecond() < Constants.GE_TAX_INCREASED) {
+		if (t < Constants.GE_TAX_INCREASED) {
 			return GeTax.getOldPostTaxPrice(price);
 		}
 		return GeTax.getPostTaxPrice(price);

--- a/src/main/java/com/flippingutilities/model/OfferEvent.java
+++ b/src/main/java/com/flippingutilities/model/OfferEvent.java
@@ -101,10 +101,13 @@ public class OfferEvent
 	 * @return post tax values
 	 */
 	public int getPrice() {
-		if (buy || time.getEpochSecond() < Constants.GE_TAX_START || itemId == Constants.BOND_ID) {
+		if (buy || time.getEpochSecond() < Constants.GE_TAX_START || Constants.TAX_EXEMPT_ITEMS.contains(itemId)) {
 			return price;
 		}
-
+		// if this occurred prior to the tax rate increasing, use the old rate
+		if (time.getEpochSecond() < Constants.GE_TAX_INCREASED) {
+			return GeTax.getOldPostTaxPrice(price);
+		}
 		return GeTax.getPostTaxPrice(price);
 	}
 

--- a/src/main/java/com/flippingutilities/utilities/Constants.java
+++ b/src/main/java/com/flippingutilities/utilities/Constants.java
@@ -1,13 +1,73 @@
 package com.flippingutilities.utilities;
 
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import net.runelite.api.gameval.ItemID;
+
 public class Constants {
     //epoch seconds that GE tax was introduced. This is not the exact time, just a close
     //enough approximation
     public static int GE_TAX_START = 1639072800;
+	// Approximate timestamp of when GE tax was increased to 2%
+	public static int GE_TAX_INCREASED = 1748514600;
     public static int GE_TAX_CAP = 5000000;
+	// Max price prior to tax being increased to 2%
+	public static int OLD_MAX_PRICE_FOR_GE_TAX = 500000000;
     public static int MAX_PRICE_FOR_GE_TAX = 250000000;
+	// Tax rate prior to 29 May 2025
+	public static double OLD_GE_TAX = 0.01; // 1%
     public static double GE_TAX = 0.02; // 2%
     public static int BOND_ID = 13190;
     public static String DUMMY_ITEM = "dummy";
+
+	public static final Set<Integer> TAX_EXEMPT_ITEMS = ImmutableSet.of(
+		ItemID.POH_TABLET_ARDOUGNETELEPORT,
+		ItemID.BASS,
+		ItemID.BREAD,
+		ItemID.BRONZE_ARROW,
+		ItemID.BRONZE_DART,
+		ItemID.CAKE,
+		ItemID.POH_TABLET_CAMELOTTELEPORT,
+		ItemID.CHISEL,
+		ItemID.POH_TABLET_FORTISTELEPORT,
+		ItemID.COOKED_CHICKEN,
+		ItemID.COOKED_MEAT,
+		ItemID._4DOSE1ENERGY,
+		ItemID._3DOSE1ENERGY,
+		ItemID._2DOSE1ENERGY,
+		ItemID._1DOSE1ENERGY,
+		ItemID.POH_TABLET_FALADORTELEPORT,
+		ItemID.NECKLACE_OF_MINIGAMES_8,
+		ItemID.GARDENING_TROWEL,
+		ItemID.HAMMER,
+		ItemID.HERRING,
+		ItemID.IRON_ARROW,
+		ItemID.IRON_DART,
+		ItemID.POH_TABLET_KOURENDTELEPORT,
+		ItemID.LOBSTER,
+		ItemID.POH_TABLET_LUMBRIDGETELEPORT,
+		ItemID.MACKEREL,
+		ItemID.MEAT_PIE,
+		ItemID.MINDRUNE,
+		ItemID.NEEDLE,
+		ItemID.OSRS_BOND,
+		ItemID.PESTLE_AND_MORTAR,
+		ItemID.PIKE,
+		ItemID.RAKE,
+		ItemID.RING_OF_DUELING_8,
+		ItemID.SALMON,
+		ItemID.POH_SAW,
+		ItemID.SECATEURS,
+		ItemID.DIBBER,
+		ItemID.SHEARS,
+		ItemID.SHRIMP,
+		ItemID.SPADE,
+		ItemID.STEEL_ARROW,
+		ItemID.STEEL_DART,
+		ItemID.POH_TABLET_TELEPORTTOHOUSE,
+		ItemID.TUNA,
+		ItemID.POH_TABLET_VARROCKTELEPORT,
+		ItemID.WATERING_CAN_0
+	);
 
 }

--- a/src/main/java/com/flippingutilities/utilities/Constants.java
+++ b/src/main/java/com/flippingutilities/utilities/Constants.java
@@ -21,6 +21,23 @@ public class Constants {
     public static String DUMMY_ITEM = "dummy";
 
 	public static final Set<Integer> TAX_EXEMPT_ITEMS = ImmutableSet.of(
+		ItemID.CHISEL,
+		ItemID.GARDENING_TROWEL,
+		ItemID.HAMMER,
+		ItemID.NEEDLE,
+		ItemID.OSRS_BOND,
+		ItemID.PESTLE_AND_MORTAR,
+		ItemID.RAKE,
+		ItemID.POH_SAW,
+		ItemID.SECATEURS,
+		ItemID.DIBBER,
+		ItemID.SHEARS,
+		ItemID.SPADE,
+		ItemID.WATERING_CAN_0
+	);
+
+	// Items made tax-exempt on 29 May 2025
+	public static final Set<Integer> NEW_TAX_EXEMPT_ITEMS = ImmutableSet.of(
 		ItemID.POH_TABLET_ARDOUGNETELEPORT,
 		ItemID.BASS,
 		ItemID.BREAD,
@@ -28,7 +45,6 @@ public class Constants {
 		ItemID.BRONZE_DART,
 		ItemID.CAKE,
 		ItemID.POH_TABLET_CAMELOTTELEPORT,
-		ItemID.CHISEL,
 		ItemID.POH_TABLET_FORTISTELEPORT,
 		ItemID.COOKED_CHICKEN,
 		ItemID.COOKED_MEAT,
@@ -38,8 +54,6 @@ public class Constants {
 		ItemID._1DOSE1ENERGY,
 		ItemID.POH_TABLET_FALADORTELEPORT,
 		ItemID.NECKLACE_OF_MINIGAMES_8,
-		ItemID.GARDENING_TROWEL,
-		ItemID.HAMMER,
 		ItemID.HERRING,
 		ItemID.IRON_ARROW,
 		ItemID.IRON_DART,
@@ -49,25 +63,15 @@ public class Constants {
 		ItemID.MACKEREL,
 		ItemID.MEAT_PIE,
 		ItemID.MINDRUNE,
-		ItemID.NEEDLE,
-		ItemID.OSRS_BOND,
-		ItemID.PESTLE_AND_MORTAR,
 		ItemID.PIKE,
-		ItemID.RAKE,
 		ItemID.RING_OF_DUELING_8,
 		ItemID.SALMON,
-		ItemID.POH_SAW,
-		ItemID.SECATEURS,
-		ItemID.DIBBER,
-		ItemID.SHEARS,
 		ItemID.SHRIMP,
-		ItemID.SPADE,
 		ItemID.STEEL_ARROW,
 		ItemID.STEEL_DART,
 		ItemID.POH_TABLET_TELEPORTTOHOUSE,
 		ItemID.TUNA,
-		ItemID.POH_TABLET_VARROCKTELEPORT,
-		ItemID.WATERING_CAN_0
+		ItemID.POH_TABLET_VARROCKTELEPORT
 	);
 
 }

--- a/src/main/java/com/flippingutilities/utilities/GeTax.java
+++ b/src/main/java/com/flippingutilities/utilities/GeTax.java
@@ -8,4 +8,13 @@ public class GeTax {
         int tax = (int)Math.floor(price * Constants.GE_TAX);
         return price - tax;
     }
+
+	// Get post tax price for transactions which occurred before the rate increase to 2%
+	public static int getOldPostTaxPrice(int price) {
+		if (price >= Constants.OLD_MAX_PRICE_FOR_GE_TAX) {
+			return price - Constants.GE_TAX_CAP;
+		}
+		int tax = (int)Math.floor(price * Constants.OLD_GE_TAX);
+		return price - tax;
+	}
 }


### PR DESCRIPTION
- Uses the previous tax rate of 1% for offers prior to the rate increase on 29 May
- Does not attempt to apply tax to items which are exempt