### PR TITLE
Fix recipe deduplication issue affecting multiple transaction selection

### DIFF
--- a/src/main/java/com/flippingutilities/controller/RecipeHandler.java
+++ b/src/main/java/com/flippingutilities/controller/RecipeHandler.java
@@ -277,35 +277,40 @@ public class RecipeHandler {
         
         while (iterator.hasNext()) {
             Recipe recipe = iterator.next();
-            String recipeKey = createRecipeKey(recipe);
+            String key = createRecipeKey(recipe);
             
-            if (uniqueRecipes.containsKey(recipeKey)) {
-                // This is a duplicate recipe, remove it
-                iterator.remove();
+            if (uniqueRecipes.containsKey(key)) {
+                iterator.remove(); // Remove duplicate
             } else {
-                uniqueRecipes.put(recipeKey, recipe);
+                uniqueRecipes.put(key, recipe); // Keep first occurrence
             }
         }
     }
 
     /**
      * Creates a unique key for a recipe based on its inputs and outputs.
-     * This is used to identify duplicate recipes.
+     * Used for identifying duplicate recipes.
      */
     private String createRecipeKey(Recipe recipe) {
-        StringBuilder key = new StringBuilder();
-        
-        // Add inputs to key
-        recipe.getInputs().stream()
-                .sorted((a, b) -> Integer.compare(a.getId(), b.getId()))
-                .forEach(input -> key.append("i").append(input.getId()).append("q").append(input.getQuantity()));
-        
-        // Add outputs to key
-        recipe.getOutputs().stream()
-                .sorted((a, b) -> Integer.compare(a.getId(), b.getId()))
-                .forEach(output -> key.append("o").append(output.getId()).append("q").append(output.getQuantity()));
-        
-        return key.toString();
+        // Sort inputs by id, quantity to ensure consistent key generation
+        String inputsKey = recipe.getInputs().stream()
+            .sorted((a, b) -> {
+                int idCompare = Integer.compare(a.getId(), b.getId());
+                return idCompare != 0 ? idCompare : Integer.compare(a.getQuantity(), b.getQuantity());
+            })
+            .map(item -> item.getId() + ":" + item.getQuantity())
+            .collect(Collectors.joining(","));
+            
+        // Sort outputs by id, quantity to ensure consistent key generation  
+        String outputsKey = recipe.getOutputs().stream()
+            .sorted((a, b) -> {
+                int idCompare = Integer.compare(a.getId(), b.getId());
+                return idCompare != 0 ? idCompare : Integer.compare(a.getQuantity(), b.getQuantity());
+            })
+            .map(item -> item.getId() + ":" + item.getQuantity())
+            .collect(Collectors.joining(","));
+            
+        return inputsKey + "|" + outputsKey;
     }
 
     private Optional<Map<Integer, PotionGroup>> getItemIdToPotionGroup(


### PR DESCRIPTION
Fix duplicate recipe handling preventing multi-transaction selection

Deduplicate recipes before indexing to resolve conflicts that prevented selecting multiple transactions of the same item for recipe creation. Fixes burning claws issue and 35+ other duplicate recipe groups.

------
## Issue

Initial issue was spotted when unable to recipe flip, sourced it down to there being duplicate receipies in the dataset found
at
https://github.com/[Flipping-Utilities/osrs-datasets](https://github.com/Flipping-Utilities/osrs-datasets)

<img width="388" height="419" alt="image" src="https://github.com/user-attachments/assets/ba754cee-22e0-421f-95aa-8150986cec25" />

<img width="599" height="575" alt="image" src="https://github.com/user-attachments/assets/48b6a27f-c3a7-4aef-a579-ffbeb52b6657" />


## Analysis

I also ran a python script to identify other duplicates in the data, but there's a lot, and this should handle it gracefully

> Major Duplication Issues Found:
> 36 groups of duplicate recipes with a total of 97 extra duplicate entries
> 
> "Burning claws" recipe appears twice (recipes #2240 and #2254) - confirming your issue!
> 
> Many basic recipes have 5-6 duplicates each:
> 
> Shrimps (5 duplicates)
> Sardine (5 duplicates)
> Pike (5 duplicates)
> Holy/Unholy symbols (6 duplicates each)
> Chocolate dust (6 duplicates)
> Cooked chicken (6 duplicates)
> All metal bars: Bronze, Iron, Silver, Gold (6 duplicates each)
> Spicy minced meat (6 duplicates)
> Other significant duplicates:
> 
> Various molten glass recipes (3 duplicates each)
> Plank making recipes (3 duplicates each for different wood types)
> Multiple crafting and cooking recipes
> Impact:
> The dataset has 2,560 total recipes but only 2,463 unique recipes after deduplication
> This 4% duplication rate is causing conflicts in recipe indexing and transaction selection