### PR TITLE
Update HistoryManager.java with a duplicate cancelled check

### DIFF
--- a/src/main/java/com/flippingutilities/model/HistoryManager.java
+++ b/src/main/java/com/flippingutilities/model/HistoryManager.java
@@ -167,6 +167,12 @@ public class HistoryManager
 		for (int i = compressedOfferEvents.size() - 1; i > -1; i--)
 		{
 			OfferEvent aPreviousOffer = compressedOfferEvents.get(i);
+
+			// if the previous offer was cancelled while a partial offer came through, the old (now invalid quantity)
+			// cancelled offer must be deleted
+			if (newOfferEvent.isUpdateForCancelled(aPreviousOffer)) {
+				compressedOfferEvents.remove(i);
+			}
 			if (aPreviousOffer.getSlot() == newOfferEvent.getSlot() && aPreviousOffer.isBuy() == newOfferEvent.isBuy())
 			{
 				//if it belongs to the same slot and its complete, it must belong to a previous trade given that

--- a/src/main/java/com/flippingutilities/model/OfferEvent.java
+++ b/src/main/java/com/flippingutilities/model/OfferEvent.java
@@ -264,6 +264,19 @@ public class OfferEvent
 			&& getPrice() == other.getPrice();
 	}
 
+	public boolean isUpdateForCancelled(OfferEvent other) {
+		return ((state == GrandExchangeOfferState.SELLING
+				&& other.getState() == GrandExchangeOfferState.CANCELLED_SELL)
+				|| (state == GrandExchangeOfferState.BUYING
+				&& other.getState() == GrandExchangeOfferState.CANCELLED_BUY))
+				&& slot == other.getSlot()
+				&& totalQuantityInTrade == other.getTotalQuantityInTrade()
+				&& itemId == other.getItemId()
+				&& getPrice() == other.getPrice()
+				&& currentQuantityInTrade != other.getCurrentQuantityInTrade()
+				&& tickArrivedAt == (other.tickArrivedAt + 1);
+	}
+
 	public static OfferEvent fromGrandExchangeEvent(GrandExchangeOfferChanged event)
 	{
 		GrandExchangeOffer offer = event.getOffer();


### PR DESCRIPTION
Update HistoryManager.java with a duplicate check that removes past offer events when they have been duplicated, which occurs when an offer is cancelled at the same tick a partial fill offer comes through