### PR TITLE
Adjust logging levels

### DIFF
--- a/src/main/java/com/flippingutilities/controller/DataHandler.java
+++ b/src/main/java/com/flippingutilities/controller/DataHandler.java
@@ -112,22 +112,22 @@ public class DataHandler {
     }
 
     public void storeData() {
-        log.info("storing data");
+        log.debug("storing data");
         if (accountsWithUnsavedChanges.size() > 0) {
-            log.info("accounts with unsaved changes are {}. Saving them.", accountsWithUnsavedChanges);
+            log.debug("accounts with unsaved changes are {}. Saving them.", accountsWithUnsavedChanges);
             accountsWithUnsavedChanges.forEach(accountName -> storeAccountData(accountName));
             accountsWithUnsavedChanges.clear();
         }
 
         if (accountWideDataChanged) {
-            log.info("accountwide data changed, saving it.");
+            log.debug("accountwide data changed, saving it.");
             storeData("accountwide", accountWideData);
             accountWideDataChanged = false;
         }
     }
 
     public void loadData() {
-        log.info("Loading data on startup");
+        log.debug("Loading data on startup");
         try {
             TradePersister.setupFlippingFolder();
         }
@@ -147,7 +147,7 @@ public class DataHandler {
     }
     
     private void backupAllAccountData() {
-        log.info("backing up account data");
+        log.debug("backing up account data");
         boolean backupCheckpointsChanged = false;
         for (String displayName : accountSpecificData.keySet()) {
             AccountData accountData = accountSpecificData.get(displayName);
@@ -167,7 +167,7 @@ public class DataHandler {
                 }
             }
             else {
-                log.info("Not backing up data for {} as it's empty or it hasn't changed since last backup", displayName);
+                log.debug("Not backing up data for {} as it's empty or it hasn't changed since last backup", displayName);
             }
         }
         if (backupCheckpointsChanged) {
@@ -177,7 +177,7 @@ public class DataHandler {
 
     private AccountWideData fetchAccountWideData() {
         try {
-            log.info("Fetching accountwide data");
+            log.debug("Fetching accountwide data");
             AccountWideData accountWideData = plugin.tradePersister.loadAccountWideData();
             boolean didActuallySetDefaults = accountWideData.setDefaults();
             accountWideDataChanged = didActuallySetDefaults;
@@ -261,7 +261,7 @@ public class DataHandler {
             AccountData data = accountSpecificData.get(displayName);
             if (data == null)
             {
-                log.info("for an unknown reason the data associated with {} has been set to null. Storing" +
+                log.debug("for an unknown reason the data associated with {} has been set to null. Storing" +
                         "an empty AccountData object instead.", displayName);
                 data = new AccountData();
             }
@@ -271,7 +271,7 @@ public class DataHandler {
         }
         catch (Exception e)
         {
-            log.info("couldn't store trades, error = " + e);
+            log.warn("couldn't store trades, error = " + e);
         }
     }
 
@@ -280,7 +280,7 @@ public class DataHandler {
             plugin.tradePersister.writeToFile(fileName, data);
         }
         catch (Exception e) {
-            log.info("couldn't store data to {} bc of {}",fileName, e);
+            log.warn("couldn't store data to {} bc of {}",fileName, e);
         }
     }
 }

--- a/src/main/java/com/flippingutilities/controller/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/controller/FlippingPlugin.java
@@ -268,7 +268,7 @@ public class FlippingPlugin extends Plugin {
 
             //this is only relevant if the user downloads/enables the plugin after they login.
             if (client.getGameState() == GameState.LOGGED_IN) {
-                log.info("user is already logged in when they downloaded/enabled the plugin");
+                log.debug("user is already logged in when they downloaded/enabled the plugin");
                 onLoggedInGameState();
             }
 
@@ -279,7 +279,7 @@ public class FlippingPlugin extends Plugin {
 
     @Override
     protected void shutDown() {
-        log.info("shutdown running!");
+        log.debug("shutdown running!");
         if (generalRepeatingTasks != null) {
             generalRepeatingTasks.cancel(true);
             generalRepeatingTasks = null;
@@ -362,13 +362,13 @@ public class FlippingPlugin extends Plugin {
     public void handleLogin(String displayName) {
         wikiDataFetcherJob.onWorldSwitch(client.getWorldType());
         if (client.getVarbitValue(VarbitID.IRONMAN) != 0) {
-                log.info("account is an ironman, not adding it to the cache");
+                log.debug("account is an ironman, not adding it to the cache");
                 return;
             }
 
-        log.info("{} has just logged in!", displayName);
+        log.debug("{} has just logged in!", displayName);
         if (!dataHandler.getCurrentAccounts().contains(displayName)) {
-            log.info("data handler does not contain data for {}", displayName);
+            log.debug("data handler does not contain data for {}", displayName);
             dataHandler.addAccount(displayName);
             masterPanel.getAccountSelector().addItem(displayName);
         }
@@ -394,7 +394,7 @@ public class FlippingPlugin extends Plugin {
         masterPanel.getAccountSelector().setSelectedItem(displayName);
 
         if (slotTimersTask == null && config.slotTimersEnabled()) {
-            log.info("starting slot timers on login");
+            log.debug("starting slot timers on login");
             slotTimersTask = startSlotTimers();
         }
         apiAuthHandler.checkRsn(displayName);
@@ -402,13 +402,13 @@ public class FlippingPlugin extends Plugin {
     }
 
     public void handleLogout() {
-        log.info("{} is logging out", currentlyLoggedInAccount);
+        log.debug("{} is logging out", currentlyLoggedInAccount);
 
         dataHandler.getAccountData(currentlyLoggedInAccount).setLastSessionTimeUpdate(null);
         dataHandler.storeData();
 
         if (slotTimersTask != null && !slotTimersTask.isCancelled()) {
-            log.info("cancelling slot timers task on logout");
+            log.debug("cancelling slot timers task on logout");
             slotTimersTask.cancel(true);
         }
         slotTimersTask = null;
@@ -430,12 +430,12 @@ public class FlippingPlugin extends Plugin {
                 statPanel.updateTimeDisplay();
                 updateSessionTime();
             } catch (ConcurrentModificationException e) {
-                log.info("concurrent modification exception. This is fine, will just restart tasks after delay." +
+                log.warn("concurrent modification exception. This is fine, will just restart tasks after delay." +
                         " Cancelling general repeating tasks and starting it again after 5000 ms delay");
                 generalRepeatingTasks.cancel(true);
                 generalRepeatingTasks = setupRepeatingTasks(5000);
             } catch (Exception e) {
-                log.info("unknown exception in repeating tasks, error = {}, will cancel and restart them after 5 sec delay", e);
+                log.warn("unknown exception in repeating tasks, error = {}, will cancel and restart them after 5 sec delay", e);
                 generalRepeatingTasks.cancel(true);
                 generalRepeatingTasks = setupRepeatingTasks(5000);
             }
@@ -508,7 +508,7 @@ public class FlippingPlugin extends Plugin {
      * @param selectedName the username the user selected from the dropdown menu.
      */
     public void changeView(String selectedName) {
-        log.info("changing view to {}", selectedName);
+        log.debug("changing view to {}", selectedName);
         accountCurrentlyViewed = selectedName;
         List<FlippingItem> itemsForCurrentView = viewItemsForCurrentView();
         statPanel.resetPaginators();
@@ -555,7 +555,7 @@ public class FlippingPlugin extends Plugin {
         String displayNameOfChangedAcc = fileName.split("\\.")[0];
 
         if (displayNameOfChangedAcc.equals(dataHandler.thisClientLastStored)) {
-            log.info("not reloading data for {} into the cache as this client was the last one to store it", displayNameOfChangedAcc);
+            log.debug("not reloading data for {} into the cache as this client was the last one to store it", displayNameOfChangedAcc);
             dataHandler.thisClientLastStored = null;
             return;
         }
@@ -571,7 +571,7 @@ public class FlippingPlugin extends Plugin {
         {
             //have to run on client thread cause loadAccount calls accountData.prepareForUse which uses the itemmanager
             clientThread.invokeLater(() -> {
-                log.info("second has passed, updating cache for {}", displayNameOfChangedAcc);
+                log.debug("second has passed, updating cache for {}", displayNameOfChangedAcc);
                 dataHandler.loadAccountData(displayNameOfChangedAcc);
                 if (!masterPanel.getViewSelectorItems().contains(displayNameOfChangedAcc)) {
                     masterPanel.getAccountSelector().addItem(displayNameOfChangedAcc);
@@ -914,7 +914,7 @@ public class FlippingPlugin extends Plugin {
                         } catch (InvalidOptionException ex) {
                             //ignore
                         } catch (Exception ex) {
-                            log.info("exception during key press for offer editor", ex);
+                            log.warn("exception during key press for offer editor", ex);
                         }
                     }));
                 }

--- a/src/main/java/com/flippingutilities/controller/RecipeHandler.java
+++ b/src/main/java/com/flippingutilities/controller/RecipeHandler.java
@@ -63,7 +63,7 @@ public class RecipeHandler {
         this.idToPotionGroup = getItemIdToPotionGroup(loadPotionGroups());
 
         if (idToRecipes.isPresent()) {
-            log.info("Successfully loaded recipes");
+            log.debug("Successfully loaded recipes");
         }
     }
 

--- a/src/main/java/com/flippingutilities/db/TradePersister.java
+++ b/src/main/java/com/flippingutilities/db/TradePersister.java
@@ -72,7 +72,7 @@ public class TradePersister
 	{
 		if (!PARENT_DIRECTORY.exists())
 		{
-			log.info("flipping directory doesn't exist yet so it's being created");
+			log.debug("flipping directory doesn't exist yet so it's being created");
 			if (!PARENT_DIRECTORY.mkdir())
 			{
 				throw new IOException("unable to create parent directory!");
@@ -80,7 +80,7 @@ public class TradePersister
 		}
 		else
 		{
-			log.info("flipping directory already exists so it's not being created");
+			log.debug("flipping directory already exists so it's not being created");
 			if (OLD_FILE.exists())
 			{
 				OLD_FILE.delete();
@@ -120,7 +120,7 @@ public class TradePersister
 	//loading from backups
 	public AccountData loadAccount(String displayName)
 	{
-		log.info("loading data for {}", displayName);
+		log.debug("loading data for {}", displayName);
 		try {
 			File accountFile = new File(PARENT_DIRECTORY, displayName + ".json");
 			AccountData accountData = loadFromFile(accountFile);
@@ -138,22 +138,22 @@ public class TradePersister
 	}
 
 	private AccountData loadAccountFromBackup(String displayName) {
-		log.info("loading data for {} from backup", displayName);
+		log.debug("loading data for {} from backup", displayName);
 		try {
 			File accountFile = new File(PARENT_DIRECTORY, displayName + ".backup.json");
 			if (!accountFile.exists()) {
-				log.info("backup for {} does not exist, returning empty AccountData", displayName);
+				log.debug("backup for {} does not exist, returning empty AccountData", displayName);
 				return new AccountData();
 			}
 			AccountData accountData = loadFromFile(accountFile);
 			if (accountData == null) {
-				log.info("data loaded from backup for {} is null for some reason, returning an empty AccountData object", displayName);
+				log.debug("data loaded from backup for {} is null for some reason, returning an empty AccountData object", displayName);
 				accountData = new AccountData();
 			}
 			return accountData;
 		}
 		catch (Exception e) {
-			log.info("Couldn't load data for {} from backup due to {}", displayName, e);
+			log.debug("Couldn't load data for {} from backup due to {}", displayName, e);
 			return new AccountData();
 		}
 	}
@@ -178,7 +178,7 @@ public class TradePersister
 
 	public BackupCheckpoints fetchBackupCheckpoints() {
 		try {
-			log.info("Fetching backup checkpoints");
+			log.debug("Fetching backup checkpoints");
 			File backupCheckpointsFile = new File(PARENT_DIRECTORY, "backupcheckpoints.special.json");
 			if (backupCheckpointsFile.exists()){
 				String backupCheckpointsJson = new String(Files.readAllBytes(backupCheckpointsFile.toPath()));
@@ -203,7 +203,7 @@ public class TradePersister
 	 */
 	public void writeToFile(String displayName, Object data) throws IOException
 	{
-		log.info("Writing to file for {}", displayName);
+		log.debug("Writing to file for {}", displayName);
 		File accountFile = new File(PARENT_DIRECTORY, displayName + ".json");
 		final String json = gson.toJson(data);
 		Files.write(accountFile.toPath(), json.getBytes());
@@ -221,11 +221,11 @@ public class TradePersister
 		{
 			if (accountFile.delete())
 			{
-				log.info("{} deleted", fileName);
+				log.debug("{} deleted", fileName);
 			}
 			else
 			{
-				log.info("unable to delete {}", fileName);
+				log.debug("unable to delete {}", fileName);
 			}
 		}
 	}

--- a/src/main/java/com/flippingutilities/jobs/CacheUpdaterJob.java
+++ b/src/main/java/com/flippingutilities/jobs/CacheUpdaterJob.java
@@ -91,7 +91,7 @@ public class CacheUpdaterJob
 	{
 		try
 		{
-			log.info("starting cache updater job!");
+			log.debug("starting cache updater job!");
 			WatchService watchService = FileSystems.getDefault().newWatchService();
 
 			Path path = TradePersister.PARENT_DIRECTORY.toPath();
@@ -103,15 +103,15 @@ public class CacheUpdaterJob
 			{
 				for (WatchEvent<?> event : key.pollEvents())
 				{
-					log.info("change in directory for {} with event: {}", event.context(), event.kind());
+					log.debug("change in directory for {} with event: {}", event.context(), event.kind());
 					if (!isDuplicateEvent(event.context().toString()))
 					{
-						log.info("not duplicate event, firing callbacks");
+						log.debug("not duplicate event, firing callbacks");
 						subscribers.forEach(subscriber -> subscriber.accept(event.context().toString()));
 					}
 					else
 					{
-						log.info("duplicate event, not firing callbacks");
+						log.debug("duplicate event, not firing callbacks");
 					}
 
 				}
@@ -125,7 +125,7 @@ public class CacheUpdaterJob
 		{
 			if (!isBeingShutdownByClient)
 			{
-				log.info("exception in updateCacheRealTime, Error = {}", e);
+				log.warn("exception in updateCacheRealTime, Error = {}", e);
 				onUnexpectedError();
 			}
 
@@ -137,30 +137,30 @@ public class CacheUpdaterJob
 
 		catch (Exception e)
 		{
-			log.info("unknown exception in updateCacheRealTime, task is going to stop. Error = {}", e);
+			log.warn("unknown exception in updateCacheRealTime, task is going to stop. Error = {}", e);
 		}
 	}
 
 	private void onUnexpectedError()
 	{
-		log.info("Failure number: {} Error not caused by client shutdown", failureCount);
+		log.debug("Failure number: {} Error not caused by client shutdown", failureCount);
 		failureCount++;
 		if (failureCount > failureThreshold)
 		{
-			log.info("number of failures exceeds failure threshold, not scheduling task again");
+			log.warn("number of failures exceeds failure threshold, not scheduling task again");
 			return;
 		}
 
 		else
 		{
-			log.info("failure count below threshold, scheduling task again");
+			log.debug("failure count below threshold, scheduling task again");
 			realTimeUpdateTask = executor.schedule(this::updateCacheRealTime, 1000, TimeUnit.MILLISECONDS);
 		}
 	}
 
 	private void onClientShutdown()
 	{
-		log.info("shutting down cache updater due to the client shutdown");
+		log.debug("shutting down cache updater due to the client shutdown");
 	}
 
 	private boolean isDuplicateEvent(String fileName)

--- a/src/main/java/com/flippingutilities/jobs/SlotSenderJob.java
+++ b/src/main/java/com/flippingutilities/jobs/SlotSenderJob.java
@@ -39,13 +39,13 @@ public class SlotSenderJob {
 
     public void start() {
         slotStateSenderTask = executor.scheduleAtFixedRate(this::sendSlots, 10, PERIOD, TimeUnit.SECONDS);
-        log.info("started slot sender job");
+        log.debug("started slot sender job");
     }
 
     public void stop() {
         if (!slotStateSenderTask.isCancelled()) {
             slotStateSenderTask.cancel(true);
-            log.info("shut down slot sender job");
+            log.debug("shut down slot sender job");
         }
     }
 

--- a/src/main/java/com/flippingutilities/jobs/WikiDataFetcherJob.java
+++ b/src/main/java/com/flippingutilities/jobs/WikiDataFetcherJob.java
@@ -51,19 +51,19 @@ public class WikiDataFetcherJob {
 
     public void start() {
         wikiDataFetchTask = executor.scheduleAtFixedRate(() -> this.attemptToFetchWikiData(false), 5,1, TimeUnit.SECONDS);
-        log.info("started wiki fetching job");
+        log.debug("started wiki fetching job");
     }
 
     public void stop() {
         if (!wikiDataFetchTask.isCancelled() && !wikiDataFetchTask.isCancelled()) {
             wikiDataFetchTask.cancel(true);
-            log.info("shut down wiki fetching job");
+            log.debug("shut down wiki fetching job");
         }
     }
 
     public void onWorldSwitch(EnumSet<WorldType> worldType) {
         if (worldType.contains(WorldType.DEADMAN)) {
-            log.info("Switching to requesting deadman api");
+            log.debug("Switching to requesting deadman api");
             apiUrl = DEADMAN_API;
         }
         else {

--- a/src/main/java/com/flippingutilities/model/FlippingItem.java
+++ b/src/main/java/com/flippingutilities/model/FlippingItem.java
@@ -353,7 +353,7 @@ public class FlippingItem implements Searchable
 
 	private void setOfferMadeBy() {
 		if (flippedBy == null) {
-			log.info("flipped by is null");
+			log.debug("flipped by is null");
 		}
 		history.setOfferMadeBy(flippedBy);
 	}

--- a/src/main/java/com/flippingutilities/ui/recipeflips/RecipeOfferSelectionPanel.java
+++ b/src/main/java/com/flippingutilities/ui/recipeflips/RecipeOfferSelectionPanel.java
@@ -481,7 +481,7 @@ public class RecipeOfferSelectionPanel extends JPanel {
         finishButton.addActionListener(e -> {
             try {
                 coinOffset.commitEdit();
-            } catch ( java.text.ParseException ex ) { log.info("Failed to parse coin offset", ex); }
+            } catch ( java.text.ParseException ex ) { log.debug("Failed to parse coin offset", ex); }
             int coinOffsetValue = (Integer) coinOffset.getValue();
             RecipeFlip recipeFlip = new RecipeFlip(recipe, selectedOffers, getCoinsCost() + coinOffsetValue);
             plugin.addRecipeFlip(recipeFlip, recipe);

--- a/src/main/java/com/flippingutilities/ui/uiutilities/Paginator.java
+++ b/src/main/java/com/flippingutilities/ui/uiutilities/Paginator.java
@@ -79,7 +79,7 @@ public class Paginator extends JPanel
 						}
 						catch (Exception exc)
 						{
-							log.info("couldn't increase page number cause callback failed");
+							log.warn("couldn't increase page number cause callback failed");
 							pageNumber--;
 						}
 					}
@@ -95,7 +95,7 @@ public class Paginator extends JPanel
 						}
 						catch (Exception exc)
 						{
-							log.info("couldn't decrease page number cause callback failed");
+							log.warn("couldn't decrease page number cause callback failed");
 							pageNumber++;
 						}
 

--- a/src/main/java/com/flippingutilities/ui/widgets/SlotActivityTimer.java
+++ b/src/main/java/com/flippingutilities/ui/widgets/SlotActivityTimer.java
@@ -229,7 +229,7 @@ public class SlotActivityTimer
 			slotStateWidget.setXTextAlignment(1);
 		}
 		catch (NullPointerException e) {
-			log.info("npe when resetting slot visuals. This is ok");
+			log.debug("npe when resetting slot visuals. This is ok");
 		}
 	}
 


### PR DESCRIPTION
Downgrades a lot of log.info usages to log.debug because the plugin can tend to clutter up users' logs, which makes troubleshooting client issues more difficult. 

Also upgrades some usages to log.warn where it seems appropriate. 