### PR TITLE
Fix: Add bounds check for slotTimers to prevent silent trade recording failure

### DIFF
--- a/src/main/java/com/flippingutilities/controller/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/controller/FlippingPlugin.java
@@ -1002,16 +1002,22 @@ public class FlippingPlugin extends Plugin {
     }
 
     private ScheduledFuture startSlotTimers() {
-        return executor.scheduleAtFixedRate(() ->
-                dataHandler.viewAccountData(currentlyLoggedInAccount).getSlotTimers().forEach(slotWidgetTimer ->
-                        clientThread.invokeLater(() -> {
-                            try {
-                                slotsPanel.updateTimerDisplays(slotWidgetTimer.getSlotIndex(), slotWidgetTimer.createFormattedTimeString());
-                                slotWidgetTimer.updateTimerDisplay();
-                            } catch (Exception e) {
-                                log.error("exception when trying to update timer", e);
-                            }
-                        })), 1000, 1000, TimeUnit.MILLISECONDS);
+        return executor.scheduleAtFixedRate(() -> {
+            List<SlotActivityTimer> slotTimers = dataHandler.viewAccountData(currentlyLoggedInAccount).getSlotTimers();
+            if (slotTimers == null || slotTimers.size() < 8) {
+                log.warn("slotTimers missing or undersized in startSlotTimers, skipping update");
+                return;
+            }
+            slotTimers.forEach(slotWidgetTimer ->
+                    clientThread.invokeLater(() -> {
+                        try {
+                            slotsPanel.updateTimerDisplays(slotWidgetTimer.getSlotIndex(), slotWidgetTimer.createFormattedTimeString());
+                            slotWidgetTimer.updateTimerDisplay();
+                        } catch (Exception e) {
+                            log.error("exception when trying to update timer", e);
+                        }
+                    }));
+        }, 1000, 1000, TimeUnit.MILLISECONDS);
     }
 
     private ScheduledFuture startAutoSave() {

--- a/src/main/java/com/flippingutilities/controller/FlippingPlugin.java
+++ b/src/main/java/com/flippingutilities/controller/FlippingPlugin.java
@@ -747,6 +747,9 @@ public class FlippingPlugin extends Plugin {
             return;
         }
 
+        if (accountData.getSlotTimers().size() < 8) {
+            return;
+        }
         for (int slotIndex = 0; slotIndex < 8; slotIndex++) {
             SlotActivityTimer timer = accountData.getSlotTimers().get(slotIndex);
             if (timer == null) {

--- a/src/main/java/com/flippingutilities/controller/NewOfferEventPipelineHandler.java
+++ b/src/main/java/com/flippingutilities/controller/NewOfferEventPipelineHandler.java
@@ -117,6 +117,11 @@ public class NewOfferEventPipelineHandler {
 
         Map<Integer, OfferEvent> lastOfferEventForEachSlot = plugin.getDataHandler().getAccountData(plugin.getCurrentlyLoggedInAccount()).getLastOffers();
         List<SlotActivityTimer> slotActivityTimers = plugin.getDataHandler().getAccountData(plugin.getCurrentlyLoggedInAccount()).getSlotTimers();
+        if (slotActivityTimers == null || slotActivityTimers.size() < 8) {
+            log.warn("slotActivityTimers is missing or undersized ({}), skipping offer screening",
+                slotActivityTimers == null ? "null" : slotActivityTimers.size());
+            return Optional.empty();
+        }
         OfferEvent lastOfferEvent = lastOfferEventForEachSlot.get(newOfferEvent.getSlot());
 
         //completely useless updates

--- a/src/main/java/com/flippingutilities/model/AccountData.java
+++ b/src/main/java/com/flippingutilities/model/AccountData.java
@@ -134,7 +134,7 @@ public class AccountData {
     }
 
     private void hydrateSlotTimers(FlippingPlugin plugin) {
-        if (slotTimers == null) {
+        if (slotTimers == null || slotTimers.size() != 8) {
             slotTimers = setupSlotTimers(plugin);
         } else {
             slotTimers.forEach(timer -> {


### PR DESCRIPTION
## Summary

- `hydrateSlotTimers()` only checks for `null`, but Gson deserializes an empty JSON array `[]` as a non-null empty `ArrayList` — bypassing initialization entirely
- The three `.get(slot)` calls in `screenOfferEvent()` then throw `IndexOutOfBoundsException` on every GE offer event, **silently dropping all real-time trades**
- GE History Tab imports (slot -1) are unaffected since they bypass `screenOfferEvent()`, which masks the failure — the plugin appears functional but records nothing
- Added bounds checks in `setWidgetsOnSlotTimers()` for the same pattern

## How I found this

I discovered this while investigating why only certain items were saving in my trade history. After my [data recovery](https://github.com/Reggie-Reuss/Runescape_FU_DataRecovery) from a RuneLite crash that corrupted both my main JSON and backup JSON simultaneously, the recovered file had `"slotTimers": []`. This caused 16 days of silent trade recording failure before I traced it to `IndexOutOfBoundsException` errors in `client.log`.

Full root cause analysis: [Phase 6: slotTimers Bug](https://github.com/Reggie-Reuss/Runescape_FU_DataRecovery/blob/master/docs/SLOT_TIMER_BUG.md)

## Is this likely in normal use?

In a **typical crash**, probably not — the plugin falls back to the backup file which usually has valid 8-entry slotTimers. But it can happen in rare edge cases:

- Both main + backup files corrupted simultaneously (my case — [documented here](https://github.com/Reggie-Reuss/Runescape_FU_DataRecovery/blob/master/docs/TIMELINE.md))
- File truncated at exactly the `slotTimers` boundary (theoretically possible for medium-sized account files in the 8-16KB range)
- Manual JSON editing or third-party tools that produce `"slotTimers": []`
- Schema changes between plugin versions

The fix is a one-line change to the root cause (`null` check → `null || size() != 8`) plus two defensive guards at the `.get()` call sites.

## Changes

| File | Change |
|------|--------|
| `AccountData.hydrateSlotTimers` | Reinitialize if `size() != 8`, not just `null` |
| `NewOfferEventPipelineHandler.screenOfferEvent` | Early return + `log.warn` if slotTimers undersized |
| `FlippingPlugin.setWidgetsOnSlotTimers` | Skip loop if list undersized |

## Note

Java is not my primary language, so this would benefit from review by someone more experienced with the codebase — similar to my other PR (#74). Happy to adjust based on feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to timer data initialization to re-create timers when missing or the count is incorrect, ensuring consistent timer state.
  * Guarded periodic timer updates to skip ticks when timer data is invalid, preventing runtime errors and improving stability.
  * Added warnings and early exits when timer lists are null or undersized to avoid unsafe operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->