### PR TITLE
Modernize build: Gradle 8.10, Java 11, Lombok 1.18.30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 repositories {
 	maven {
-		url = 'http://repo.runelite.net'
+		url = 'https://repo.runelite.net'
 	}
 	mavenCentral()
 }
@@ -14,8 +14,8 @@ def runeLiteVersion = 'latest.release'
 
 dependencies {
     compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
-    compileOnly 'org.projectlombok:lombok:1.18.4'
-    annotationProcessor 'org.projectlombok:lombok:1.18.4'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
     implementation "org.apache.commons:commons-csv:1.4"
 
@@ -28,10 +28,10 @@ dependencies {
 
 group = 'com.flippingutilities'
 version = '1.4.1'
-sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+	options.release.set(11)
 }
 
 tasks.register('runPlugin', JavaExec) {

--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,12 @@ repositories {
 }
 
 def runeLiteVersion = 'latest.release'
+def lombokVersion = '1.18.30'
 
 dependencies {
     compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
-    compileOnly 'org.projectlombok:lombok:1.18.30'
-    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     implementation "org.apache.commons:commons-csv:1.4"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
Align the build config with the current RuneLite plugin template:

- **Gradle** 6.6.1 → 8.10 (fixes local builds on Java 17+/21)
- **Java target** `sourceCompatibility = '1.8'` → `options.release.set(11)` (matches what the plugin hub forces via `target_init.gradle`)
- **Lombok** 1.18.4 → 1.18.30
- **Repo URL** `http://repo.runelite.net` → `https://repo.runelite.net`

## Motivation
The old Gradle 6.6.1 can't run on Java 17+ due to class file version incompatibilities (`Unsupported class file major version 65`). This means contributors on modern JDKs can't build or run tests locally. The plugin hub already overrides the Java target to 11, so this just makes local dev match production.

## Test
- `./gradlew build` passes cleanly on Java 21
- `./gradlew test` — all existing tests pass
- No source code changes, just build config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Gradle from 6.6.1 to 8.10.
  * Upgraded Lombok to 1.18.30 and centralized its version.
  * Switched Maven repository endpoint to HTTPS.
  * Set Java compilation target to Java 11 and enforced UTF-8 encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->